### PR TITLE
BlogController::indexAction() url changed ('/blog' to '/') 

### DIFF
--- a/Controller/BlogController.php
+++ b/Controller/BlogController.php
@@ -8,7 +8,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 class BlogController extends Controller
 {
     /**
-     * @Route("/blog", name="blog_index")
+     * @Route("/", name="blog_index")
      */
     public function indexAction()
     {


### PR DESCRIPTION
If we want the index url like /blog that's probably because we want all routes with '/blog' prefix.

We could achieve this with:

<pre>
blog:                                                                                                                                          
    resource: "@PSSBlogBundle/Controller/BlogController.php"
    type: annotation
    prefix: /blog
</pre>


PSSBlogBundle is really great thanks :)
